### PR TITLE
Mark all MM changes as :FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]

### DIFF
--- a/Configs(For forking)/IgnitorAIES.cfg
+++ b/Configs(For forking)/IgnitorAIES.cfg
@@ -1,5 +1,5 @@
 // AIES Constellation C6
-@PART[liquidEngineconstelacion]
+@PART[liquidEngineconstelacion]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -23,7 +23,7 @@
 }
 
 // AIES Des-T5 Radial Engine
-@PART[dest5Engine]
+@PART[dest5Engine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -48,7 +48,7 @@
 }
 
 // AIES Exper-05
-@PART[engineexper05]
+@PART[engineexper05]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -71,7 +71,7 @@
 }
 
 // AIES Mogul MP1500
-@PART[liquidEnginemogulmp1500]
+@PART[liquidEnginemogulmp1500]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -94,7 +94,7 @@
 }
 
 // AIES Produll VR2
-@PART[liquidEngineprodulVR2]
+@PART[liquidEngineprodulVR2]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -118,7 +118,7 @@
 }
 
 // AIES Galaxy VR2
-@PART[galaxvr2]
+@PART[galaxvr2]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -142,7 +142,7 @@
 }
 
 // AIES MODC-2
-@PART[enginelmodc]
+@PART[enginelmodc]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -167,7 +167,7 @@
 }
 
 // AIES Orbit II
-@PART[liquidEngineorbit2]
+@PART[liquidEngineorbit2]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -191,7 +191,7 @@
 }
 
 // AIES EX-1 SAT Engine
-@PART[microEngineex1sat]
+@PART[microEngineex1sat]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -216,7 +216,7 @@
 }
 
 // AIES M-SE Engine
-@PART[microEngineSE1]
+@PART[microEngineSE1]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {

--- a/Configs(For forking)/IgnitorAIES.cfg
+++ b/Configs(For forking)/IgnitorAIES.cfg
@@ -222,19 +222,14 @@
     {
         name = ModuleEngineIgnitor
         ignitionsAvailable = 200
-        autoIgnitionTemperature = 700
-        ignitorType = Internal_Small
+        autoIgnitionTemperature = 550
+        ignitorType = Electric
 	useUllageSimulation = false
         IGNITOR_RESOURCE
         {
-            name = LiquidFuel
-            amount = 0.045
+            name = ElectricCharge
+            amount = 0.25
         }
-        IGNITOR_RESOURCE
-        {
-            name = Oxidizer
-            amount = 0.055
-        }
-	// Hypergolic propellant, 200 Ignitions due to depreciation (Using LiquidFuel + Oxidizer)
+	// 200 Ignitions due to depreciation (Using ElectricCharge)
     }
 }

--- a/Configs(For forking)/IgnitorBobcatSovietEngines.cfg
+++ b/Configs(For forking)/IgnitorBobcatSovietEngines.cfg
@@ -1,0 +1,177 @@
+@PART[NK33]
+{
+    RESOURCE
+    {
+	name = HypergolicFluid
+	amount = 2
+	maxAmount = 2
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 4
+        autoIgnitionTemperature = 800
+        ignitorType = Internal_Medium
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 1
+            // 2 Ignitions (Using HypergolicFluid)
+        }
+    }
+}
+
+@PART[NK43]
+{
+    RESOURCE
+    {
+	name = HypergolicFluid
+	amount = 2
+	maxAmount = 2
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 4
+        autoIgnitionTemperature = 800
+        ignitorType = Internal_Medium
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 1
+            // 2 Ignitions (Using HypergolicFluid)
+        }
+    }
+}
+
+@PART[RD0120]
+{
+    RESOURCE
+    {
+	name = HypergolicFluid
+	amount = 10
+	maxAmount = 10
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = External
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 10
+            // 1 Ignitions (Using HypergolicFluid, External)
+        }
+    }
+}
+
+@PART[RD0124]
+{
+    RESOURCE
+    {
+	name = HypergolicFluid
+	amount = 8
+	maxAmount = 8
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 8
+        autoIgnitionTemperature = 800
+        ignitorType = Internal_Medium
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 2
+            // 4 Ignitions (Using HypergolicFluid)
+        }
+    }
+}
+
+@PART[RD0146]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 5
+        autoIgnitionTemperature = 600
+        ignitorType = Internal_Medium
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 20
+            // 5 Ignitions due to depreciation (Using ElectricCharge)
+        }
+    }
+}
+
+@PART[RD171]
+{
+    RESOURCE
+    {
+	name = HypergolicFluid
+	amount = 10
+	maxAmount = 10
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 2
+        autoIgnitionTemperature = 800
+        ignitorType = Internal_Large
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 10
+            // 1 Ignitions (Using HypergolicFluid)
+        }
+    }
+}
+
+@PART[RD180]
+{
+    RESOURCE
+    {
+	name = HypergolicFluid
+	amount = 10
+	maxAmount = 10
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 2
+        autoIgnitionTemperature = 800
+        ignitorType = Internal_Large
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 10
+            // 1 Ignitions (Using HypergolicFluid)
+        }
+    }
+}
+
+@PART[RD191]
+{
+    RESOURCE
+    {
+	name = HypergolicFluid
+	amount = 10
+	maxAmount = 10
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 2
+        autoIgnitionTemperature = 800
+        ignitorType = Internal_Large
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 10
+            // 1 Ignitions (Using HypergolicFluid)
+        }
+    }
+}

--- a/Configs(For forking)/IgnitorBobcatSovietEngines.cfg
+++ b/Configs(For forking)/IgnitorBobcatSovietEngines.cfg
@@ -1,4 +1,4 @@
-@PART[NK33]
+@PART[NK33]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -21,7 +21,7 @@
     }
 }
 
-@PART[NK43]
+@PART[NK43]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -44,7 +44,7 @@
     }
 }
 
-@PART[RD0120]
+@PART[RD0120]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -67,7 +67,7 @@
     }
 }
 
-@PART[RD0124]
+@PART[RD0124]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -90,7 +90,7 @@
     }
 }
 
-@PART[RD0146]
+@PART[RD0146]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -107,7 +107,7 @@
     }
 }
 
-@PART[RD171]
+@PART[RD171]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -130,7 +130,7 @@
     }
 }
 
-@PART[RD180]
+@PART[RD180]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -153,7 +153,7 @@
     }
 }
 
-@PART[RD191]
+@PART[RD191]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {

--- a/Configs(For forking)/IgnitorKOSMOS.cfg
+++ b/Configs(For forking)/IgnitorKOSMOS.cfg
@@ -1,5 +1,5 @@
 // RD-33NK
-@PART[Kosmos_Angara_RD-33NK]
+@PART[Kosmos_Angara_RD-33NK]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -23,7 +23,7 @@
 }
 
 // RD-0146
-@PART[Kosmos_Angara_RD-0146]
+@PART[Kosmos_Angara_RD-0146]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -41,7 +41,7 @@
 }
 
 // RD-210
-@PART[Kosmos_Angara_RD-275K]
+@PART[Kosmos_Angara_RD-275K]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -64,7 +64,7 @@
 }
 
 // RD-58SS
-@PART[Kosmos_RD-58SS]
+@PART[Kosmos_RD-58SS]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -88,7 +88,7 @@
 }
 
 // TKS RD-0225 Monopropellant Engine
-@PART[Kosmos_TKS_RD-0225_Engine]
+@PART[Kosmos_TKS_RD-0225_Engine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {

--- a/Configs(For forking)/IgnitorKW.cfg
+++ b/Configs(For forking)/IgnitorKW.cfg
@@ -1,5 +1,5 @@
 // KW Maverick-1D
-@PART[KW1mengineMaverick1D]
+@PART[KW1mengineMaverick1D]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -28,7 +28,7 @@
 }
 
 // KW Rocketry Vesta VR-1
-@PART[KW1mengineVestaVR1]
+@PART[KW1mengineVestaVR1]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -52,7 +52,7 @@
 }
 
 // KW Rocketry WildCat-V
-@PART[KW1mengineWildCatV]
+@PART[KW1mengineWildCatV]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -75,7 +75,7 @@
 }
 
 // KW Rocketry Griffon-G8D
-@PART[KW2mengineGriffonG8D]
+@PART[KW2mengineGriffonG8D]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -93,7 +93,7 @@
 }
 
 // KW Rocketry Maverick-V
-@PART[KW2mengineMaverickV]
+@PART[KW2mengineMaverickV]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -117,7 +117,7 @@
 }
 
 // Service Propulsion System
-@PART[KW2mengineSPS]
+@PART[KW2mengineSPS]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -135,7 +135,7 @@
 }
 
 // KW Rocketry Vesta VR-9D
-@PART[KW2mengineVestaVR9D]
+@PART[KW2mengineVestaVR9D]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -159,7 +159,7 @@
 }
 
 // KW Rocketry Griffon XX
-@PART[KW3mengineGriffonXX]
+@PART[KW3mengineGriffonXX]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -177,7 +177,7 @@
 }
 
 // KW Rocketry Titan-T1
-@PART[KW3mengineTitanT1]
+@PART[KW3mengineTitanT1]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -201,7 +201,7 @@
 }
 
 // KW Rocketry Wildcat-XR
-@PART[KW3mengineWildcarXR]
+@PART[KW3mengineWildcarXR]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -230,7 +230,7 @@
 }
 
 // KW Rocketry Griffon XL
-@PART[KW5mengineGriffonXL]
+@PART[KW5mengineGriffonXL]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -248,7 +248,7 @@
 }
 
 // KW Rocketry Titan-T2
-@PART[KW5mengineTitanT2]
+@PART[KW5mengineTitanT2]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {

--- a/Configs(For forking)/IgnitorKW.cfg
+++ b/Configs(For forking)/IgnitorKW.cfg
@@ -127,15 +127,10 @@
         ignitorType = Internal_Medium
         IGNITOR_RESOURCE
         {
-            name = LiquidFuel
-            amount = 0.18
+            name = MonoPropellant
+            amount = 0.4
 	}
-	IGNITOR_RESOURCE
-        {
-            name = Oxidizer
-            amount = 0.22
-	}
-        // 100 Ignitions due to depreciation (Using LiquidFuel + Oxidizer)
+        // 100 Ignitions due to depreciation (Using MonoPropellant)
     }
 }
 

--- a/Configs(For forking)/IgnitorNASA.cfg
+++ b/Configs(For forking)/IgnitorNASA.cfg
@@ -1,5 +1,5 @@
 // S3 KS-25x4 Engine Cluster
-@PART[Size3EngineCluster]
+@PART[Size3EngineCluster]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -17,7 +17,7 @@
 }
 
 // Kerbodyne KR-2L Advanced Engine
-@PART[Size3AdvancedEngine]
+@PART[Size3AdvancedEngine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -41,7 +41,7 @@
 }
 
 // LFB KR-1x2
-@PART[Size2LFB]
+@PART[Size2LFB]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {

--- a/Configs(For forking)/IgnitorNASA.cfg
+++ b/Configs(For forking)/IgnitorNASA.cfg
@@ -1,0 +1,65 @@
+// S3 KS-25x4 Engine Cluster
+@PART[Size3EngineCluster]
+{
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 0
+        autoIgnitionTemperature = 800
+        ignitorType = External
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 75.0
+            // 1 Ignition (Through Launch Stability Enhancer)
+        }
+    }
+}
+
+// Kerbodyne KR-2L Advanced Engine
+@PART[Size3AdvancedEngine]
+{
+    RESOURCE
+    {
+        name = HypergolicFluid
+        amount = 24
+        maxAmount = 24
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 3
+        autoIgnitionTemperature = 800
+        ignitorType = Internal_Large
+        IGNITOR_RESOURCE
+        {
+            name = ElectricCharge
+            amount = 45
+            // 3 Ignitions (Using ElectricCharge)
+        }
+    }
+}
+
+// LFB KR-1x2
+@PART[Size2LFB]
+{
+    RESOURCE
+    {
+        name = HypergolicFluid
+        amount = 15
+        maxAmount = 15
+    }
+    MODULE
+    {
+        name = ModuleEngineIgnitor
+        ignitionsAvailable = 1
+        autoIgnitionTemperature = 800
+        ignitorType = Internal_Medium
+        IGNITOR_RESOURCE
+        {
+            name = HypergolicFluid
+            amount = 15
+            // 1 Ignition (Using HypergolicFluid)
+        }
+    }
+}

--- a/Configs(For forking)/IgnitorNovaPunch.cfg
+++ b/Configs(For forking)/IgnitorNovaPunch.cfg
@@ -1,5 +1,5 @@
 // LF-A30 Aerospike Engine
-@PART[NP_lfe_125m_AerospikeEngine]
+@PART[NP_lfe_125m_AerospikeEngine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -23,7 +23,7 @@
 }
 
 // Basic Bertha Mini Quad
-@PART[NP_lfe_125m_berthaminiquad]
+@PART[NP_lfe_125m_berthaminiquad]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -47,7 +47,7 @@
 }
 
 // K2-X Liquid Fuel Rocket Engine
-@PART[NP_lfe_125m_K2XEngine]
+@PART[NP_lfe_125m_K2XEngine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -71,7 +71,7 @@
 }
 
 // RMA-3 Orbital Achievement Device
-@PART[NP_lfe_125m_RMA3]
+@PART[NP_lfe_125m_RMA3]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -95,7 +95,7 @@
 }
 
 // SLS-125 Bearcat Series One
-@PART[NP_lfe_125m_BearcatSingle]
+@PART[NP_lfe_125m_BearcatSingle]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -108,7 +108,7 @@
 }
 
 // SLS-250 Bearcat Series Two
-@PART[NP_lfe_25m_BroncoSingle]
+@PART[NP_lfe_25m_BroncoSingle]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -121,7 +121,7 @@
 }
 
 // Bearcat Series Two Tri-Nozzle
-@PART[NP_lfe_375m_Bearcat3x]
+@PART[NP_lfe_375m_Bearcat3x]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -134,7 +134,7 @@
 }
 
 // Bearcat Series Two 5x
-@PART[NP_lfe_5m_Bearcat5x]
+@PART[NP_lfe_5m_Bearcat5x]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -147,7 +147,7 @@
 }
 
 // 4X-800 Liquid Fuel Engine Cluster
-@PART[NP_lfe_25m_4X800Engine]
+@PART[NP_lfe_25m_4X800Engine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -171,7 +171,7 @@
 }
 
 // NERVA Mk.I NTR
-@PART[NP_lfe_25m_NERVA]
+@PART[NP_lfe_25m_NERVA]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -185,7 +185,7 @@
 }
 
 // In-line Twin Fission Rocket Engine 1.25m
-@PART[NP_lfe_125m_NERVA_Inline]
+@PART[NP_lfe_125m_NERVA_Inline]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -199,7 +199,7 @@
 }
 
 // In-line Twin Fission Rocket Engine 2.5m
-@PART[NP_lfe_25m_NERVA_Inline]
+@PART[NP_lfe_25m_NERVA_Inline]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -213,7 +213,7 @@
 }
 
 // Orbital Bertha
-@PART[NP_lfe_25m_Orbitalbertha]
+@PART[NP_lfe_25m_Orbitalbertha]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -237,7 +237,7 @@
 }
 
 // TD-180 Bronco Quad
-@PART[NP_lfe_375m_EnergiaQuad]
+@PART[NP_lfe_375m_EnergiaQuad]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -261,7 +261,7 @@
 }
 
 // The Little Mother
-@PART[NP_lfe_375m_LittleMother]
+@PART[NP_lfe_375m_LittleMother]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -285,7 +285,7 @@
 }
 
 // The Matriarch
-@PART[NP_lfe_5m_TheMatriarch]
+@PART[NP_lfe_5m_TheMatriarch]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {

--- a/Configs(For forking)/IgnitorRLA.cfg
+++ b/Configs(For forking)/IgnitorRLA.cfg
@@ -1,5 +1,5 @@
 // Rockomax Cutter Linear Aerospike Engine
-@PART[RLA_linearspike_med]
+@PART[RLA_linearspike_med]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -23,7 +23,7 @@
 }
 
 // MPR-45 Monopropellant Engine
-@PART[RLA_mp_med]
+@PART[RLA_mp_med]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -36,7 +36,7 @@
 }
 
 // MPR-5 Monopropellant Engine
-@PART[RLA_mp_small]
+@PART[RLA_mp_small]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -50,7 +50,7 @@
 }
 
 // MPR-5R Monopropellant Engine
-@PART[RLA_mp_rad]
+@PART[RLA_mp_rad]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -64,7 +64,7 @@
 }
 
 // LV-T5 Liquid Fuel Engine
-@PART[RLA_s_midengine]
+@PART[RLA_s_midengine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -88,7 +88,7 @@
 }
 
 // LV-Nc Atomic Engine
-@PART[RLA_s_nerva]
+@PART[RLA_s_nerva]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {

--- a/Configs(For forking)/IgnitorStock.cfg
+++ b/Configs(For forking)/IgnitorStock.cfg
@@ -1,5 +1,5 @@
 // TT18-A Launch Stability Enhancer
-@PART[launchClamp1]
+@PART[launchClamp1]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -11,7 +11,7 @@
 }
 
 // Rockomax "Mailsail" Engine
-@PART[liquidEngine1-2]
+@PART[liquidEngine1-2]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -29,7 +29,7 @@
 }
 
 // Rockomax "Skipper" Engine
-@PART[engineLargeSkipper]
+@PART[engineLargeSkipper]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -53,7 +53,7 @@
 }
 
 // Rockomax "Poodle" Engine
-@PART[liquidEngine2-2]
+@PART[liquidEngine2-2]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -77,7 +77,7 @@
 }
 
 // LV-N Atomic Engine
-@PART[nuclearEngine]
+@PART[nuclearEngine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     MODULE
     {
@@ -91,7 +91,7 @@
 }
 
 // Toroidal Aerospike Engine
-@PART[toroidalAerospike]
+@PART[toroidalAerospike]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -115,7 +115,7 @@
 }
 
 // LV-T30 Engine
-@PART[liquidEngine]
+@PART[liquidEngine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -139,7 +139,7 @@
 }
 
 // LV-T45 Engine
-@PART[liquidEngine2]
+@PART[liquidEngine2]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -163,7 +163,7 @@
 }
 
 // Rockomax Mark 55 Radial Engine
-@PART[radialLiquidEngine1-2]
+@PART[radialLiquidEngine1-2]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -187,7 +187,7 @@
 }
 
 // LV-909 Engine
-@PART[liquidEngine3]
+@PART[liquidEngine3]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -211,7 +211,7 @@
 }
 
 // Rockomax 48-7S
-@PART[liquidEngineMini]
+@PART[liquidEngineMini]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -235,7 +235,7 @@
 }
 
 // Rockomax 24-77 Engine
-@PART[smallRadialEngine]
+@PART[smallRadialEngine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -260,7 +260,7 @@
 }
 
 // LV-1 Engine
-@PART[microEngine]
+@PART[microEngine]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {
@@ -285,7 +285,7 @@
 }
 
 // LV-1R Engine
-@PART[radialEngineMini]
+@PART[radialEngineMini]:FOR[EngineIgnitor]:NEEDS[!RealismOverhaul]
 {
     RESOURCE
     {

--- a/Configs(For forking)/IgnitorStock.cfg
+++ b/Configs(For forking)/IgnitorStock.cfg
@@ -274,7 +274,7 @@
         ignitionsAvailable = 80
         autoIgnitionTemperature = 500
         ignitorType = Electric
-	useUllageSimulation = false
+        useUllageSimulation = false
         IGNITOR_RESOURCE
         {
             name = ElectricCharge


### PR DESCRIPTION
This means we should be able to bundle all these configs with the standard module install, rather than needing the user to find and unzip files.

Closes #4.
Unblocks KSP-CKAN/CKAN-Meta#11
Unblocks KSP-CKAN/CKAN-Meta#12
